### PR TITLE
Fix multi-window InApp message display for iPad Stage Manager (MOB-11622)

### DIFF
--- a/swift-sdk/Internal/Utilities/IterableUtil.swift
+++ b/swift-sdk/Internal/Utilities/IterableUtil.swift
@@ -8,6 +8,21 @@ import UIKit
 
 @objc final class IterableUtil: NSObject {
     static var rootViewController: UIViewController? {
+        if #available(iOS 13.0, *) {
+            // Modern scene-based approach for multi-window support
+            for scene in UIApplication.shared.connectedScenes {
+                if let windowScene = scene as? UIWindowScene {
+                    for window in windowScene.windows {
+                        if window.isKeyWindow {
+                            return window.rootViewController
+                        }
+                    }
+                }
+            }
+            // If no key window found, fallback to legacy approach
+        }
+        
+        // Legacy approach for iOS 12 and below, or fallback
         if let rootViewController = AppExtensionHelper.application?.delegate?.window??.rootViewController {
             return rootViewController
         } else {


### PR DESCRIPTION
## Problem

**MOB-11622**: Washington Post reported that InApp messages are not displaying in the active window when using iPad with Stage Manager and multiple windows open.

### Root Cause
Our current `IterableUtil.rootViewController` implementation falls back to `UIApplication.shared.windows.first?.rootViewController` which just grabs the **first** window, not the **active/key** window that the user is currently interacting with.

## Solution

Updated `IterableUtil.rootViewController` to use **scene-based window detection** for iOS 13+:

- ✅ **Iterates through `UIApplication.shared.connectedScenes`** to find active window scenes
- ✅ **Identifies the key window** using `window.isKeyWindow` 
- ✅ **Returns the active window's root view controller**
- ✅ **Maintains backward compatibility** with iOS 12 fallback logic
- ✅ **Zero breaking changes** - same method signature and behavior

## Changes Made

**File**: `swift-sdk/Internal/Utilities/IterableUtil.swift`
- Added iOS 13+ availability check
- Implemented scene-based window traversal logic
- Preserved existing fallback behavior for older iOS versions

## Testing

### ✅ Automated Tests
- **Build**: ✅ Passed
- **Unit Tests**: ✅ Passed (no existing tests broken)

### Manual Testing Instructions

**Prerequisites:**
- iPad with iOS 13+ 
- Stage Manager enabled
- Test app with Iterable SDK integrated

**Test Steps:**
1. Open your app on iPad
2. Enable Stage Manager in Control Center
3. Tap app icon in dock → use "+" button to open second window
4. Trigger an InApp message in one window
5. **Expected**: Message appears in the **active** window you're interacting with
6. **Previous behavior**: Message appeared in first/wrong window

**Edge Cases to Test:**
- Switch between windows and trigger messages in each
- Test with 3+ windows open
- Verify iOS 12 devices still work (fallback logic)
- Test single window scenarios (should behave identically)

## Impact

- ✅ **Fixes Washington Post's multi-window issue**
- ✅ **Improves UX for all iPad users with Stage Manager**
- ✅ **No risk to existing functionality**
- ✅ **Future-proof for Apple's multi-window direction**

Closes MOB-11622
